### PR TITLE
feat(EP-502) seq interval

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -2776,7 +2776,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1120;
+				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					275315D414ACF0A10065964D = {
 						DevelopmentTeam = N2Q372V7W2;

--- a/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/Continuous iOS.xcscheme
+++ b/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/Continuous iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/CBLSequenceMap.h
+++ b/Source/CBLSequenceMap.h
@@ -29,11 +29,4 @@
 
 @property (readonly) BOOL isEmpty;
 
-/** Returns the maximum consecutively-removed sequence number.
-    This is one less than the minimum remaining sequence number. */
-- (SequenceNumber) checkpointedSequence;
-
-/** Returns the value associated with the checkpointedSequence. */
-- (id) checkpointedValue;
-
 @end

--- a/Source/CBLSequenceMap.h
+++ b/Source/CBLSequenceMap.h
@@ -29,4 +29,11 @@
 
 @property (readonly) BOOL isEmpty;
 
+/** Returns the maximum consecutively-removed sequence number.
+    This is one less than the minimum remaining sequence number. */
+- (SequenceNumber) checkpointedSequence;
+
+/** Returns the value associated with the checkpointedSequence. */
+- (id) checkpointedValue;
+
 @end

--- a/Source/CBLSequenceMap.m
+++ b/Source/CBLSequenceMap.m
@@ -52,68 +52,26 @@
     return _sequences.firstIndex == NSNotFound;
 }
 
-
-- (SequenceNumber) checkpointedSequence {
-    NSUInteger sequence = _sequences.firstIndex;
-    sequence = (sequence == NSNotFound) ? _lastSequence : sequence-1;
-    
-    if (sequence > _firstValueSequence) {
-        // Garbage-collect inaccessible values:
-        NSUInteger numToRemove = sequence - _firstValueSequence;
-        [_values removeObjectsInRange: NSMakeRange(0, numToRemove)];
-        _firstValueSequence += numToRemove;
-    }
-    return sequence;
-}
-
-
-- (id) checkpointedValue {
-    NSInteger index = (NSInteger)([self checkpointedSequence] - _firstValueSequence);
-    return (index >= 0) ? _values[index] : nil;
-}
-
-
 @end
 
 
 
 TestCase(CBLSequenceMap) {
     CBLSequenceMap* map = [[CBLSequenceMap alloc] init];
-    CAssertEq(map.checkpointedSequence, 0);
-    CAssertEqual(map.checkpointedValue, nil);
     CAssert(map.isEmpty);
     
     CAssertEq([map addValue: @"one"], 1);
-    CAssertEq(map.checkpointedSequence, 0);
-    CAssertEqual(map.checkpointedValue, nil);
     CAssert(!map.isEmpty);
     
     CAssertEq([map addValue: @"two"], 2);
-    CAssertEq(map.checkpointedSequence, 0);
-    CAssertEqual(map.checkpointedValue, nil);
-    
     CAssertEq([map addValue: @"three"], 3);
-    CAssertEq(map.checkpointedSequence, 0);
-    CAssertEqual(map.checkpointedValue, nil);
     
     [map removeSequence: 2];
-    CAssertEq(map.checkpointedSequence, 0);
-    CAssertEqual(map.checkpointedValue, nil);
-    
     [map removeSequence: 1];
-    CAssertEq(map.checkpointedSequence, 2);
-    CAssertEqual(map.checkpointedValue, @"two");
     
     CAssertEq([map addValue: @"four"], 4);
-    CAssertEq(map.checkpointedSequence, 2);
-    CAssertEqual(map.checkpointedValue, @"two");
     
     [map removeSequence: 3];
-    CAssertEq(map.checkpointedSequence, 3);
-    CAssertEqual(map.checkpointedValue, @"three");
-    
     [map removeSequence: 4];
-    CAssertEq(map.checkpointedSequence, 4);
-    CAssertEqual(map.checkpointedValue, @"four");
     CAssert(map.isEmpty);
 }

--- a/Source/CBLSequenceMap.m
+++ b/Source/CBLSequenceMap.m
@@ -52,26 +52,65 @@
     return _sequences.firstIndex == NSNotFound;
 }
 
+- (SequenceNumber) checkpointedSequence {
+    NSUInteger sequence = _sequences.firstIndex;
+    sequence = (sequence == NSNotFound) ? _lastSequence : sequence-1;
+    
+    if (sequence > _firstValueSequence) {
+        // Garbage-collect inaccessible values:
+        NSUInteger numToRemove = sequence - _firstValueSequence;
+        [_values removeObjectsInRange: NSMakeRange(0, numToRemove)];
+        _firstValueSequence += numToRemove;
+    }
+    return sequence;
+}
+
+- (id) checkpointedValue {
+    NSInteger index = (NSInteger)([self checkpointedSequence] - _firstValueSequence);
+    return (index >= 0) ? _values[index] : nil;
+}
+
 @end
 
 
 
 TestCase(CBLSequenceMap) {
     CBLSequenceMap* map = [[CBLSequenceMap alloc] init];
+    CAssertEq(map.checkpointedSequence, 0);
+    CAssertEqual(map.checkpointedValue, nil);
     CAssert(map.isEmpty);
     
     CAssertEq([map addValue: @"one"], 1);
+    CAssertEq(map.checkpointedSequence, 0);
+    CAssertEqual(map.checkpointedValue, nil);
     CAssert(!map.isEmpty);
     
     CAssertEq([map addValue: @"two"], 2);
+    CAssertEq(map.checkpointedSequence, 0);
+    CAssertEqual(map.checkpointedValue, nil);
+    
     CAssertEq([map addValue: @"three"], 3);
+    CAssertEq(map.checkpointedSequence, 0);
+    CAssertEqual(map.checkpointedValue, nil);
     
     [map removeSequence: 2];
+    CAssertEq(map.checkpointedSequence, 0);
+    CAssertEqual(map.checkpointedValue, nil);
+    
     [map removeSequence: 1];
+    CAssertEq(map.checkpointedSequence, 2);
+    CAssertEqual(map.checkpointedValue, @"two");
     
     CAssertEq([map addValue: @"four"], 4);
+    CAssertEq(map.checkpointedSequence, 2);
+    CAssertEqual(map.checkpointedValue, @"two");
     
     [map removeSequence: 3];
+    CAssertEq(map.checkpointedSequence, 3);
+    CAssertEqual(map.checkpointedValue, @"three");
+
     [map removeSequence: 4];
+    CAssertEq(map.checkpointedSequence, 4);
+    CAssertEqual(map.checkpointedValue, @"four");
     CAssert(map.isEmpty);
 }

--- a/Source/CBLSequenceMap.m
+++ b/Source/CBLSequenceMap.m
@@ -36,6 +36,7 @@
 - (SequenceNumber) addValue: (id)value {
     [_sequences addIndex: ++_lastSequence];
     [_values addObject: value];
+
     return _lastSequence;
 }
 

--- a/Source/CBLView+Querying.m
+++ b/Source/CBLView+Querying.m
@@ -24,10 +24,6 @@
 #import "FMResultSet.h"
 #import "ExceptionUtils.h"
 
-
-#define kReduceBatchSize 100
-
-
 const CBLQueryOptions kDefaultCBLQueryOptions = {
     .limit = UINT_MAX,
     .inclusiveEnd = YES,

--- a/Source/CBL_Puller.h
+++ b/Source/CBL_Puller.h
@@ -42,6 +42,7 @@
     bool _conflicted;
 }
 
+/// Sequence ID received from a remote server. Can be nil.
 @property (copy) id remoteSequenceID;
 @property bool conflicted;
 

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -62,12 +62,6 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     }
     if (!_pendingSequences) {
         _pendingSequences = [[CBLSequenceMap alloc] init];
-        if (_lastSequence != nil) {
-            // Prime _pendingSequences so its checkpointedValue will reflect the last known seq:
-            SequenceNumber seq = [_pendingSequences addValue: _lastSequence];
-            [_pendingSequences removeSequence: seq];
-            AssertEqual(_pendingSequences.checkpointedValue, _lastSequence);
-        }
     }
     
     _caughtUp = NO;
@@ -287,7 +281,6 @@ static NSString* joinQuotedEscaped(NSArray* strings);
         LogTo(SyncVerbose, @"%@: no new remote revisions to fetch", self);
         SequenceNumber seq = [_pendingSequences addValue: lastInboxSequence];
         [_pendingSequences removeSequence: seq];
-        self.lastSequence = _pendingSequences.checkpointedValue;
         return;
     }
     
@@ -616,9 +609,6 @@ static NSString* joinQuotedEscaped(NSArray* strings);
               self, (unsigned)downloads.count);
         return kCBLStatusOK;
     }];
-
-    // Checkpoint:
-    self.lastSequence = _pendingSequences.checkpointedValue;
 
     time = CFAbsoluteTimeGetCurrent() - time;
     LogTo(Sync, @"%@ inserted %u revs (%u in history) in %.3f sec (%.1f/sec)",

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -103,6 +103,13 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     _changeTracker.filterParameters = _filterParameters;
     _changeTracker.docIDs = _docIDs;
     _changeTracker.authorizer = _authorizer;
+    
+    // Specify interval at which sequence values should be calculated to increase the calculation speed on server.
+    // This value comes from the remote server.
+    id seqIntervalObj = _options[kCBLReplicatorOption_SeqInterval];
+    if ([seqIntervalObj respondsToSelector:@selector(unsignedIntValue)]) {
+        _changeTracker.seqInterval = [seqIntervalObj unsignedIntValue];
+    }
 
     unsigned heartbeat = $castIf(NSNumber, _options[kCBLReplicatorOption_Heartbeat]).unsignedIntValue;
     if (heartbeat >= 15000)

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -639,7 +639,6 @@ static NSString* joinQuotedEscaped(NSArray* strings);
 
 @synthesize remoteSequenceID=_remoteSequenceID, conflicted=_conflicted;
 
-
 @end
 
 

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -124,3 +124,4 @@ extern NSString* CBL_ReplicatorStoppedNotification;
 #define kCBLReplicatorOption_BulkGet @"bulk_get"            // Force using the non-standard _bulk_get call which speeds-up replication
 #define kCBLReplicatorOption_IgnoreRemoved @"ignore_removed"// Ignore items in changes feed with removed:true
 #define kCBLReplicatorOption_BatchSize @"batch_size"        // Size for inbox batcher, _bulk_get request and for downloads insert batcher
+#define kCBLReplicatorOption_SeqInterval @"seq_interval"    // seq_interval value to be used in changes feed

--- a/Source/CBL_Replicator.m
+++ b/Source/CBL_Replicator.m
@@ -180,7 +180,6 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
     }
 }
 
-
 - (void) postProgressChanged {
     LogTo(SyncVerbose, @"%@: postProgressChanged (%u/%u, active=%d (batch=%u, net=%u), online=%d)",
           self, (unsigned)_changesProcessed, (unsigned)_changesTotal,

--- a/Source/ChangeTracker/CBLChangeTracker.h
+++ b/Source/ChangeTracker/CBLChangeTracker.h
@@ -28,6 +28,7 @@
                                deleted: (BOOL)deleted
                                removed: (BOOL)removed;
 - (void) changeTrackerFinished;
+- (void) setLastSequence:(NSString*)lastSequence;
 @optional
 - (void) changeTrackerStopped: (CBLChangeTracker*)tracker;
 @end

--- a/Source/ChangeTracker/CBLChangeTracker.h
+++ b/Source/ChangeTracker/CBLChangeTracker.h
@@ -60,6 +60,7 @@ typedef enum CBLChangeTrackerMode {
     NSDictionary* _requestHeaders;
     id<CBLAuthorizer> _authorizer;
     unsigned _retryCount;
+    unsigned _seqInterval;
 }
 
 - (instancetype) initWithDatabaseURL: (NSURL*)databaseURL
@@ -85,6 +86,8 @@ typedef enum CBLChangeTrackerMode {
 @property (nonatomic) unsigned limit;
 @property (nonatomic) NSTimeInterval heartbeat;
 @property (nonatomic) NSArray *docIDs;
+
+@property (nonatomic) unsigned seqInterval;
 
 - (BOOL) start;
 - (void) stop;

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -36,6 +36,7 @@
 @synthesize client=_client, filterName=_filterName, filterParameters=_filterParameters;
 @synthesize requestHeaders = _requestHeaders, authorizer=_authorizer;
 @synthesize docIDs = _docIDs, pollInterval=_pollInterval;
+@synthesize seqInterval = _seqInterval;
 
 - (instancetype) initWithDatabaseURL: (NSURL*)databaseURL
                                 mode: (CBLChangeTrackerMode)mode
@@ -135,6 +136,11 @@
             [path appendFormat: @"&%@=%@", CBLEscapeURLParam(key),
                                            CBLEscapeURLParam(value)];
         }
+    }
+    
+    // Add seq interval to skip calculating certain sequences
+    if (_seqInterval && _seqInterval > 0) {
+        [path appendFormat: @"&seq_interval=%u", _seqInterval];
     }
 
     return path;

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -29,12 +29,6 @@
 #define kInitialRetryDelay 2.0      // Initial retry delay (doubles after every subsequent failure)
 #define kMaxRetryDelay (10*60.0)    // ...but will never get longer than this
 
-
-//@interface CBLChangeTracker ()
-//@property (readwrite, copy, nonatomic) id lastSequenceID;
-//@end
-
-
 @implementation CBLChangeTracker
 
 @synthesize lastSequenceID=_lastSequenceID, databaseURL=_databaseURL, mode=_mode;
@@ -223,8 +217,6 @@
             return;
         
         id sequence = [change objectForKey: @"seq"];
-        if (!sequence)
-            return;
         
         NSString* docID = [change objectForKey: @"id"];
         if (!docID || ![docID isKindOfClass: [NSString class]])

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -84,7 +84,7 @@
         _mode = mode;
         _heartbeat = kDefaultHeartbeat;
         _includeConflicts = includeConflicts;
-        self.lastSequenceID = lastSequenceID;
+        _lastSequenceID = lastSequenceID;
     }
     return self;
 }
@@ -272,14 +272,6 @@
     }
     NSDictionary* changeDict = $castIf(NSDictionary, changeObj);
     
-    NSString *lastSequence = $castIf(NSString, changeDict[@"last_seq"]);
-    if (!lastSequence) {
-        if (errorMessage)
-            *errorMessage = @"No 'last_seq' field in response";
-        return -1;
-    }
-    self.lastSequenceID = lastSequence;
-    
     NSArray* changes = $castIf(NSArray, changeDict[@"results"]);
     if (!changes) {
         if (errorMessage)
@@ -288,8 +280,16 @@
     }
     if (![self receivedChanges: changes errorMessage: errorMessage])
         return -1;
+    
+    NSString *lastSequence = $castIf(NSString, changeDict[@"last_seq"]);
+    if (!lastSequence) {
+        if (errorMessage)
+            *errorMessage = @"No 'last_seq' field in response";
+        return -1;
+    }
+    [self.client setLastSequence:lastSequence];
+    
     return changes.count;
 }
-
 
 @end

--- a/Source/ChangeTracker/CBLConnectionChangeTracker.m
+++ b/Source/ChangeTracker/CBLConnectionChangeTracker.m
@@ -30,7 +30,7 @@
         return NO;
     [super start];
     _inputBuffer = [[NSMutableData alloc] init];
-
+    
     NSMutableURLRequest* request = nil;
     if (self.docIDs) {
         NSMutableString* path = [NSMutableString string];
@@ -46,6 +46,11 @@
         }
         if (_limit > 0)
             [path appendFormat: @"&limit=%u", _limit];
+        
+        // Add seq interval to skip calculating certain sequences
+        if (_seqInterval && _seqInterval > 0) {
+            [path appendFormat: @"&seq_interval=%u", _seqInterval];
+        }
         
         request = [NSMutableURLRequest requestWithURL: CBLAppendToURL(_databaseURL, path)];
         request.HTTPMethod = @"POST";


### PR DESCRIPTION
NB: This PR needs to be merged together with [SpotMe PR](https://github.com/Spotme/spotme3-mobile-ios/pull/2301).

[EP-3633](https://spotme.atlassian.net/jira/software/projects/EP/boards/44?assignee=5e09afa50242870e996e5cb2&label=iOS&selectedIssue=EP-3633) addressed: "last_sequence" param is not used to checkpoint the changes
[EP-502](https://spotme.atlassian.net/jira/software/projects/EP/boards/44?assignee=5e09afa50242870e996e5cb2&label=iOS&selectedIssue=EP-502) addressed: "seq_interval" param has been added to changes request to avoid complex calculations of sequence values.

Testing:
I have tested on iPhone 6s, iPad Pro simulator, iPhone 11 simulator.

Using existing application and installing from scratch
making changes on backstage and refreshing app via
a) timer-based refreshing
b) sync button in app menu
c) pull to refresh
d) reopening app

Expected result: the behaviour of the app should remain unchanged.